### PR TITLE
Support to load Pkcs8 key as is. #3

### DIFF
--- a/tests/Unit/PrivateKeyConstructTest.php
+++ b/tests/Unit/PrivateKeyConstructTest.php
@@ -61,4 +61,12 @@ class PrivateKeyConstructTest extends TestCase
         $this->expectExceptionMessage('Private key is not PEM');
         new PrivateKey('INVALID+CONTENT', '');
     }
+    
+    public function testConstructWithPkcs8Content(): void
+    {
+        $filename = $this->fileContents('CSD01_AAA010101AAA/private_key.key');
+        $password = trim($this->fileContents('CSD01_AAA010101AAA/password.txt'));
+        $privateKey = new PrivateKey($filename, $password);
+        $this->assertGreaterThan(0, $privateKey->numberOfBits());
+    }
 }

--- a/tests/Unit/PrivateKeyConstructTest.php
+++ b/tests/Unit/PrivateKeyConstructTest.php
@@ -50,23 +50,31 @@ class PrivateKeyConstructTest extends TestCase
 
     public function testConstructWithInvalidContent(): void
     {
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Private key is not PEM');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot open private key');
         new PrivateKey('invalid content', '');
     }
 
     public function testConstructWithInvalidButBase64Content(): void
     {
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Private key is not PEM');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot open private key');
         new PrivateKey('INVALID+CONTENT', '');
     }
     
     public function testConstructWithPkcs8Content(): void
     {
-        $filename = $this->fileContents('CSD01_AAA010101AAA/private_key.key');
+        $content = $this->fileContents('CSD01_AAA010101AAA/private_key.key');
         $password = trim($this->fileContents('CSD01_AAA010101AAA/password.txt'));
-        $privateKey = new PrivateKey($filename, $password);
+        $privateKey = new PrivateKey($content, $password);
+        $this->assertGreaterThan(0, $privateKey->numberOfBits());
+    }
+    
+    public function testConstructWithPkcs8Base64Content(): void
+    {
+        $content = base64_encode($this->fileContents('CSD01_AAA010101AAA/private_key.key'));
+        $password = trim($this->fileContents('CSD01_AAA010101AAA/password.txt'));
+        $privateKey = new PrivateKey($content, $password);
         $this->assertGreaterThan(0, $privateKey->numberOfBits());
     }
 }


### PR DESCRIPTION
Se agrega funcionalidad para que el constructor de PrivateKey pueda cargar el contenido del archivo .key tal y como está y no tener que pasarlo primero a .pem