### PR TITLE
Mejorar la construcción del proyecto y la integración contínua

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -39,7 +39,10 @@ return PhpCsFixer\Config::create()
         'single_blank_line_before_namespace' => true,
         'linebreak_after_opening_tag' => true,
         'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
+        'ordered_imports' => [
+            'imports_order' => ['class', 'const', 'function'],
+            'sort_algorithm' => 'alpha',
+        ],
         'array_syntax' => ['syntax' => 'short'],
     ])
     ->setFinder(

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,18 @@ language: php
 # php compatibility
 php: ["7.2", "7.3", "7.4", "8.0"]
 
-env:
-  global:
-    - PHP_CS_FIXER_IGNORE_ENV=yes
-
 cache:
   - directories:
     - $HOME/.composer
 
 before_script:
   - phpenv config-rm xdebug.ini || true
-  - travis_retry composer install --no-interaction --prefer-dist
+  - travis_retry composer self-update --no-progress --no-interaction --2 --stable
+  - travis_retry composer update --no-progress --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/php-cs-fixer fix --verbose
-  - vendor/bin/phpcbf --colors -sp src/ tests/
+  - PHP_CS_FIXER_IGNORE_ENV=yes vendor/bin/php-cs-fixer fix --using-cache=no --verbose --dry-run
+  - vendor/bin/phpcs --colors -sp src/ tests/
   - vendor/bin/phpunit --testdox --verbose
   - vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/
 

--- a/composer.json
+++ b/composer.json
@@ -41,17 +41,17 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:test"],
         "dev:check-style": [
-            "vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "vendor/bin/phpcs --colors -sp src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --dry-run --verbose",
+            "@php vendor/bin/phpcs --colors -sp src/ tests/"
         ],
         "dev:fix-style": [
-            "vendor/bin/php-cs-fixer fix --verbose",
-            "vendor/bin/phpcbf --colors -sp src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --verbose",
+            "@php vendor/bin/phpcbf --colors -sp src/ tests/"
         ],
         "dev:test": [
             "@dev:check-style",
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/"
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 Nos apegamos a [SEMVER](SEMVER.md), revisa la información para entender mejor el control de versiones.
 
+## UNRELEASED 2020-12-20
+
+- Se actualiza `composer.json` para que los scripts se ejecuten con el mismo ejecutable de PHP que fue
+  usado para invocar a `composer`.
+- Se actualiza Travis-CI para que reporte errores usando `phpcs` y `php-cs-fixer`.
+- phpcs: Se ignoran las funciones deprecadas en el código para que la construcción pase.
+- php-cs-fixer: Se reconfigura la regla `ordered_imports`.
+
 ## Version 1.1.2 2020-12-20
 
 - Desde esta versión se soporta PHP 8.0. Se hicieron cambios porque en la nueva versión de PHP la librería

--- a/src/PrivateKey.php
+++ b/src/PrivateKey.php
@@ -157,7 +157,9 @@ class PrivateKey extends Key
             return call_user_func($function, $privateKey);
         } finally {
             if (PHP_VERSION_ID < 80000) {
+                // phpcs:disable Generic.PHP.DeprecatedFunctions.Deprecated
                 openssl_free_key($privateKey);
+                // phpcs:enable
             }
         }
     }

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -100,7 +100,9 @@ class PublicKey extends Key
             return call_user_func($function, $pubKey);
         } finally {
             if (PHP_VERSION_ID < 80000) {
+                // phpcs:disable Generic.PHP.DeprecatedFunctions.Deprecated
                 openssl_free_key($pubKey);
+                // phpcs:enable
             }
         }
     }


### PR DESCRIPTION
Nota: No hay cambios en el código, no es necesaria una nueva versión

- Se actualiza `composer.json` para que los scripts se ejecuten con el mismo ejecutable de PHP que fue usado para invocar a `composer`.
- Se actualiza Travis-CI para que reporte errores usando `phpcs` y `php-cs-fixer`.
- phpcs: Se ignoran las funciones deprecadas en el código para que la construcción pase.
- php-cs-fixer: Se reconfigura la regla `ordered_imports`.
