### PR TITLE
Mantenimiento 2022-01-31

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,5 +15,5 @@
 /.php-cs-fixer.dist.php     export-ignore
 /.scrutinizer.yml           export-ignore
 /phpcs.xml.dist             export-ignore
-/phpstan.xml.dist           export-ignore
+/phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-/.github/*  @phpcfdi/core-mantainers
+/.github/*  @phpcfdi/core-maintainers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,106 +1,107 @@
 name: build
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
   push:
-    branches: [ main ]
+    branches: [ "main" ]
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 
+# Actions
+# shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+# sudo-bot/action-scrutinizer@latest https://github.com/marketplace/actions/action-scrutinizer
+
 jobs:
 
-  ci: # this job runs all the development tools and upload code coverage to scrutinizer
-
-    name: PHP 8.0 (full)
+  phpcs:
+    name: Code style (phpcs)
     runs-on: "ubuntu-latest"
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
-          extensions: mbstring, openssl
-          coverage: xdebug
-          tools: composer:v2, phpcs, php-cs-fixer, phpstan, cs2pr
+          coverage: none
+          tools: composer:v2, cs2pr, phpcs
         env:
           fail-fast: true
+      - name: Code style (phpcs)
+        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
 
+  php-cs-fixer:
+    name: Code style (php-cs-fixer)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, cs2pr, php-cs-fixer
+        env:
+          fail-fast: true
+      - name: Code style (php-cs-fixer)
+        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+
+  phpstan:
+    name: Code analysis (phpstan)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, phpstan
+        env:
+          fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
-
-      - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle | cs2pr
-
-      - name: Code style (php-cs-fixer)
-        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
-
-      - name: Tests (phpunit with code coverage)
-        run: vendor/bin/phpunit --testdox --verbose --coverage-clover=build/coverage-clover.xml --coverage-xml=build/coverage --log-junit=build/coverage/junit.xml
-
-      - name: Code analysis (phpstan)
+      - name: PHPStan
         run: phpstan analyse --no-progress --verbose
 
-      # see https://github.com/marketplace/actions/action-scrutinizer
-      - name: Upload code coverage to scrutinizer
-        uses: sudo-bot/action-scrutinizer@latest
-        with:
-          cli-args: "--format=php-clover build/coverage-clover.xml"
-        continue-on-error: true
-
-  build: # this job runs tests on all php supported versions
-
-    name: PHP ${{ matrix.php-versions }} (tests)
+  tests:
+    name: Tests on PHP ${{ matrix.php-versions }}
     runs-on: "ubuntu-latest"
-
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4']
-
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
-
-      # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, openssl
           coverage: none
-          tools: composer:v2, cs2pr
+          tools: composer:v2
         env:
           fail-fast: true
-
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
-
-      - name: Tests
+      - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.1.0" installed="3.1.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.6.0" installed="3.6.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.0" installed="3.6.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^0.12.98" installed="0.12.98" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.5.0" installed="3.5.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.4.4" installed="1.4.4" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -10,11 +10,12 @@ build:
     override:
       - composer update --no-interaction --prefer-dist
   nodes:
-    analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/ 
+    analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
       project_setup: {override: true}
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis
-
-tools:
-  external_code_coverage: true
+          - command: vendor/bin/phpunit --verbose --testdox --coverage-clover=coverage.clover
+            coverage:
+              file: coverage.clover
+              format: clover

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,9 @@ composer dev:build
 
 ## Ejecutar GitHub Actions localmente
 
-Puedes usar [`act`](https://github.com/nektos/act) para ejecutar GitHub Actions localmente, tal como se
-muestra en [`actions/setup-php-action`](https://github.com/marketplace/actions/setup-php-action#local-testing-setup)
-puedes ejecutar el siguiente comando:
+Puedes utilizar la herramienta [`act`](https://github.com/nektos/act) para ejecutar las GitHub Actions localmente.
+Según [`actions/setup-php-action`](https://github.com/marketplace/actions/setup-php-action#local-testing-setup)
+puedes ejecutar el siguiente comando para revisar los flujos de trabajo localmente:
 
 ```shell
 act -P ubuntu-latest=shivammathur/node:latest

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2021 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2022 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Para entender más de los formatos de llaves privadas se puede consultar la sigu
 Esta librería se mantendrá compatible con al menos la versión con
 [soporte activo de PHP](https://www.php.net/supported-versions.php) más reciente.
 
-También utilizamos [Versionado Semántico 2.0.0](https://semver.org/lang/es/) por lo que puedes usar esta librería
+También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes usar esta librería
 sin temor a romper tu aplicación.
 
 ## Contribuciones

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,16 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 1.1.4 2022-01-31
+
+- Se mejora la forma en como son procesados los tipos de datos del certificado.
+- Se actualiza el año de licencia. ¡Feliz 2022!
+- Se actualizan las herramientas de desarrollo, en especial PHPStan 1.4.4.
+- Se hacen las correcciones a los problemas detectados por PHPStan.
+- Se mejoran las pruebas y se incrementa la cobertura de código.
+- Se actualiza el flujo de *CI* llevando los pasos a trabajos y se agrega PHP 8.1.
+- Se actualiza el nombre del grupo de mantenedores de phpCfdi.
+
 ### Versión 1.1.3 2021-09-03
 
 - La versión menor de PHP es 7.3.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
     </testsuites>
     <coverage>
         <include>
-            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">src</directory>
         </include>
     </coverage>
 </phpunit>

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -52,8 +52,8 @@ class Certificate
         }
         $this->pem = $pem;
         $this->dataArray = $parsed;
-        $this->rfc = strval(strstr(($parsed['subject']['x500UniqueIdentifier'] ?? '') . ' ', ' ', true));
-        $this->legalName = strval($parsed['subject']['name'] ?? '');
+        $this->rfc = strval(strstr($this->subjectData('x500UniqueIdentifier') . ' ', ' ', true));
+        $this->legalName = $this->subjectData('name');
     }
 
     /**
@@ -126,12 +126,12 @@ class Certificate
     /** @return array<string, string> */
     public function subject(): array
     {
-        return $this->extractArray('subject');
+        return $this->extractArrayStrings('subject');
     }
 
     public function subjectData(string $key): string
     {
-        return strval($this->subject()[$key] ?? null);
+        return strval($this->subject()[$key] ?? '');
     }
 
     public function hash(): string
@@ -142,7 +142,7 @@ class Certificate
     /** @return array<string, string> */
     public function issuer(): array
     {
-        return $this->extractArray('issuer');
+        return $this->extractArrayStrings('issuer');
     }
 
     public function issuerData(string $string): string
@@ -210,7 +210,7 @@ class Certificate
     /** @return array<string, string> */
     public function extensions(): array
     {
-        return $this->extractArray('extensions');
+        return $this->extractArrayStrings('extensions');
     }
 
     public function publicKey(): PublicKey

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -82,7 +82,7 @@ class Certificate
      */
     public static function openFile(string $filename): self
     {
-        return new self(static::localFileOpen($filename));
+        return new self(self::localFileOpen($filename));
     }
 
     public function pem(): string

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -45,7 +45,6 @@ class Certificate
             $pem = static::convertDerToPem($contents);
         }
 
-        /** @var array<mixed>|false $parsed */
         $parsed = openssl_x509_parse($pem, true);
         if (false === $parsed) {
             throw new UnexpectedValueException('Cannot parse X509 certificate from contents');

--- a/src/Internal/DataArrayTrait.php
+++ b/src/Internal/DataArrayTrait.php
@@ -13,7 +13,6 @@ trait DataArrayTrait
     protected $dataArray;
 
     /**
-     * @param string $key
      * @param string|int|float|bool $default
      * @return string|int|float|bool
      */
@@ -40,10 +39,7 @@ trait DataArrayTrait
         return 0;
     }
 
-    /**
-     * @param string $key
-     * @return array<mixed>
-     */
+    /** @return array<mixed> */
     protected function extractArray(string $key): array
     {
         $data = $this->dataArray[$key] ?? null;
@@ -51,6 +47,18 @@ trait DataArrayTrait
             return [];
         }
         return $data;
+    }
+
+    /** @return array<string, string> */
+    protected function extractArrayStrings(string $key): array
+    {
+        $array = [];
+        foreach ($this->extractArray($key) as $name => $value) {
+            if (is_scalar($value) || is_object($value)) {
+                $array[$name] = strval($value);
+            }
+        }
+        return $array;
     }
 
     protected function extractDateTime(string $key): DateTimeImmutable

--- a/src/PrivateKey.php
+++ b/src/PrivateKey.php
@@ -108,6 +108,7 @@ class PrivateKey extends Key
                 if (false === $this->openSslSign($data, $signature, $privateKey, $algorithm)) {
                     throw new RuntimeException('Cannot sign data: ' . openssl_error_string());
                 }
+                $signature = strval($signature);
                 if ('' === $signature) {
                     throw new RuntimeException('Cannot sign data: empty signature');
                 }

--- a/src/PrivateKey.php
+++ b/src/PrivateKey.php
@@ -79,7 +79,7 @@ class PrivateKey extends Key
      */
     public static function openFile(string $filename, string $passPhrase): self
     {
-        return new self(static::localFileOpen($filename), $passPhrase);
+        return new self(self::localFileOpen($filename), $passPhrase);
     }
 
     public function pem(): string

--- a/src/PrivateKey.php
+++ b/src/PrivateKey.php
@@ -184,7 +184,9 @@ class PrivateKey extends Key
                     'encrypt_key' => ('' !== $newPassPhrase), // if empty then set that the key is not encrypted
                 ];
                 if (! openssl_pkey_export($privateKey, $exported, $newPassPhrase, $exportConfig)) {
+                    // @codeCoverageIgnoreStart
                     throw new RuntimeException('Cannot export the private KEY to change password');
+                    // @codeCoverageIgnoreEnd
                 }
                 return $exported;
             }

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -29,7 +29,7 @@ class PublicKey extends Key
 
     public static function openFile(string $filename): self
     {
-        return new self(static::localFileOpen($filename));
+        return new self(self::localFileOpen($filename));
     }
 
     /**

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\Credentials;
 
 use Closure;
+use OpenSSLAsymmetricKey;
 use PhpCfdi\Credentials\Internal\Key;
 use PhpCfdi\Credentials\Internal\LocalFileOpenTrait;
 use RuntimeException;
@@ -59,9 +60,10 @@ class PublicKey extends Key
 
     /**
      * This method id created to wrap and mock openssl_verify
+     *
      * @param string $data
      * @param string $signature
-     * @param mixed $publicKey
+     * @param OpenSSLAsymmetricKey $publicKey
      * @param int $algorithm
      * @return int
      */
@@ -77,8 +79,9 @@ class PublicKey extends Key
     /**
      * Run a closure with this public key opened
      *
-     * @param Closure $function
-     * @return mixed
+     * @template T
+     * @param Closure(OpenSSLAsymmetricKey): T $function
+     * @return T
      */
     public function callOnPublicKey(Closure $function)
     {
@@ -86,19 +89,21 @@ class PublicKey extends Key
     }
 
     /**
-     * @param Closure $function
+     * @template T
+     * @param Closure(OpenSSLAsymmetricKey): T $function
      * @param string $publicKeyContents
-     * @return mixed
+     * @return T
      * @throws RuntimeException when Cannot open public key
      */
     private static function callOnPublicKeyWithContents(Closure $function, string $publicKeyContents)
     {
+        /** @var false|OpenSSLAsymmetricKey $pubKey */
         $pubKey = openssl_get_publickey($publicKeyContents);
         if (false === $pubKey) {
             throw new RuntimeException('Cannot open public key: ' . openssl_error_string());
         }
         try {
-            return call_user_func($function, $pubKey);
+            return $function($pubKey);
         } finally {
             if (PHP_VERSION_ID < 80000) {
                 // phpcs:disable Generic.PHP.DeprecatedFunctions.Deprecated

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -71,7 +71,7 @@ class PublicKey extends Key
     {
         $verify = openssl_verify($data, $signature, $publicKey, $algorithm);
         if (false === $verify) {
-            return -1;
+            return -1; // @codeCoverageIgnore
         }
         return $verify;
     }

--- a/tests/Unit/Internal/LocalFileOpenTraitTest.php
+++ b/tests/Unit/Internal/LocalFileOpenTraitTest.php
@@ -24,6 +24,14 @@ class LocalFileOpenTraitTest extends TestCase
         $this->assertStringEqualsFile($filename, $specimen->localFileOpen($filename));
     }
 
+    public function testOpenEmptyFile(): void
+    {
+        $specimen = new LocalFileOpenTraitSpecimen();
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('The file to open is empty');
+        $specimen->localFileOpen('');
+    }
+
     public function testOpenWithDubleSchemeOnPath(): void
     {
         $filename = 'file://http://example.com/index.htm';


### PR DESCRIPTION
- Se mejora la forma en como son procesados los tipos de datos del certificado.
- Se actualiza el año de licencia. ¡Feliz 2022!
- Se actualizan las herramientas de desarrollo, en especial PHPStan 1.4.4.
- Se hacen las correcciones a los problemas detectados por PHPStan.
- Se mejoran las pruebas y se incrementa la cobertura de código.
- Se actualiza el flujo de *CI* llevando los pasos a trabajos y se agrega PHP 8.1.
- Se actualiza el nombre del grupo de mantenedores de phpCfdi.

Nota: Con este PR se corrige el build de CI!