### PR TITLE
Elimina la compatiblidad con PHP 7.3, PHP 7.4 y PHP 8.0 (versión 1.3.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,4 +121,4 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Tests (phpunit)
-        run: vendor/bin/phpunit --testdox --verbose
+        run: vendor/bin/phpunit --testdox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,18 +93,18 @@ jobs:
         run: phpstan analyse --no-progress --verbose
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer-normalize
         env:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -73,7 +73,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -97,7 +97,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Create code coverage
-        run: vendor/bin/phpunit --testdox --verbose --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
+        run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -79,7 +79,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   tests-coverage:
-    name: Tests on PHP 8.0 (code coverage)
+    name: Tests on PHP (code coverage)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,7 +6,7 @@ on:
 
 # Actions
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
-# sonarsource/sonarcloud-github-action@master https://github.com/marketplace/actions/sonarcloud-scan
+# SonarSource/sonarqube-scan-action@v5 https://github.com/marketplace/actions/official-sonarqube-scan
 
 jobs:
 
@@ -103,7 +103,6 @@ jobs:
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/junit.xml > build/sonar-junit.xml
           sed 's#'$GITHUB_WORKSPACE'#/github/workspace#g' build/coverage/clover.xml > build/sonar-coverage.xml
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.58.1" installed="3.74.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.10.1" installed="3.12.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.10.1" installed="3.12.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.75.0" installed="3.75.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.12.1" installed="3.12.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.12.1" installed="3.12.1" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^2.1.11" installed="2.1.11" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.42.0" installed="2.45.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="composer-normalize" version="^2.46.0" installed="2.46.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.58.1" installed="3.58.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.10.1" installed="3.10.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.10.1" installed="3.10.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.11.4" installed="1.11.4" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.42.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.58.1" installed="3.74.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.10.1" installed="3.12.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.10.1" installed="3.12.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.11" installed="2.1.11" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.42.0" installed="2.45.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,8 +15,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHP73Migration' => true,
+        '@PHP74Migration:risky' => true,
+        '@PHP74Migration' => true,
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,7 +15,7 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP80Migration' => true,
+        '@PHP81Migration' => true,
         '@PHP80Migration:risky' => true,
         // symfony
         'class_attributes_separation' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,8 +15,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP74Migration:risky' => true,
-        '@PHP74Migration' => true,
+        '@PHP80Migration' => true,
+        '@PHP80Migration:risky' => true,
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2024 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2025 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ $pfxReader = new PfxReader();
 $credential = $pfxReader->createCredentialFromContents('contenido-del-archivo', 'pfx-passphrase');
 
 // crea un objeto Credential dada la ruta local de un archivo pfx
-$credential = $pfxReader->createCredentialsFromFile('pfxFilePath', 'pfx-passphrase');
+$credential = $pfxReader->createCredentialFromFile('pfxFilePath', 'pfx-passphrase');
 ```
 
 ## Compatibilidad

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/phpcfdi/credentials"
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "eclipxe/enum": "^0.2.7"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/phpcfdi/credentials"
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "eclipxe/enum": "^0.2.7"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": ">=7.3",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "eclipxe/enum": "^0.2.0"
+        "eclipxe/enum": "^0.2.7"
     },
     "require-dev": {
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^10.5.45"
     },
     "prefer-stable": true,
     "autoload": {
@@ -61,7 +61,7 @@
             "@php tools/phpcs --colors -sp"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"
         ],
         "dev:fix-style": [
             "@php tools/composer-normalize normalize",
@@ -69,7 +69,7 @@
             "@php tools/phpcbf --colors -sp"
         ],
         "dev:test": [
-            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php vendor/bin/phpunit --testdox --stop-on-failure",
             "@php tools/phpstan analyse --no-progress --verbose"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "source": "https://github.com/phpcfdi/credentials"
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "eclipxe/enum": "^0.2.7"

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "keywords": [
         "efirma",
         "fiel",
+        "csd",
         "sat",
         "cfdi",
         "sello",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 1.3.0 2025-04-12
+
+- Se mejoran las declaraciones de tipos.
+- Se elimina la compatiblidad con PHP 7.3, PHP 7.4 y PHP 8.0.
+- Se actualiza la acción de GitHub a `Update to SonarSource/sonarqube-scan-action@v5`.
+
 ### Versión 1.2.3 2025-03-30
 
 Se corrigieron los problemas asociados a la compatibilidad de PHP 8.4.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,23 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 ## Listado de cambios
 
+### Versión 1.2.3 2025-03-30
+
+Se corrigieron los problemas asociados a la compatibilidad de PHP 8.4.
+
+- Se agregó explícitamente el operador de tipos *nullable* `?`.
+- Se actualizó la dependencia `eclipxe/enum` a una versión compatible con PHP 8.4.
+
+Se actualiza el año de licencia a 2025.
+
+Se hicieron cambios menores al código sugeridos por PHPStan y PSalm.
+
+Adicionalmente, se hacen los siguientes cambios internos:
+
+- Se agrega PHP 8.4 a la matriz de pruebas del flujo de trabajo `build`.
+- Se ejecuta la mayoría de los trabajos de los flujos de trabajo usando PHP 8.4.
+- Se actualizan las herramientas de desarrollo.
+
 ### Versión 1.2.2 2024-06-06
 
 Se corrigió el problema de no crear correctamente el número de serie cuando incluía caracteres en mayúsculas.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,14 +5,14 @@
     bootstrap="tests/bootstrap.php"
     colors="true"
     >
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -59,7 +59,6 @@ class Certificate
      * Convert X.509 DER base64 or X.509 DER to X.509 PEM
      *
      * @param string $contents can be a certificate format X.509 DER or X.509 DER base64
-     * @return string
      */
     public static function convertDerToPem(string $contents): string
     {
@@ -77,7 +76,6 @@ class Certificate
      * The content file can be a certificate format X.509 PEM, X.509 DER or X.509 DER base64
      *
      * @param string $filename must be a local file (without scheme or file:// scheme)
-     * @return Certificate
      */
     public static function openFile(string $filename): self
     {

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -16,19 +16,19 @@ class Certificate
     use LocalFileOpenTrait;
 
     /** @var string PEM contents including headers */
-    private $pem;
+    private string $pem;
 
     /** @var string RFC as parsed from subject/x500UniqueIdentifier */
-    private $rfc;
+    private string $rfc;
 
     /** @var string Legal name as parsed from subject/x500UniqueIdentifier */
-    private $legalName;
+    private string $legalName;
 
     /** @var SerialNumber|null Parsed serial number */
-    private $serialNumber;
+    private ?SerialNumber $serialNumber = null;
 
     /** @var PublicKey|null Parsed public key */
-    private $publicKey;
+    private ?PublicKey $publicKey = null;
 
     /**
      * Certificate constructor

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -235,7 +235,7 @@ class Certificate
         if (null === $datetime) {
             $datetime = new DateTimeImmutable();
         }
-        return ($datetime >= $this->validFromDateTime() && $datetime <= $this->validToDateTime());
+        return $datetime >= $this->validFromDateTime() && $datetime <= $this->validToDateTime();
     }
 
     protected function createSerialNumber(string $hexadecimal, string $decimal): SerialNumber

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -230,7 +230,7 @@ class Certificate
         return SatTypeEnum::csd();
     }
 
-    public function validOn(DateTimeImmutable $datetime = null): bool
+    public function validOn(?DateTimeImmutable $datetime = null): bool
     {
         if (null === $datetime) {
             $datetime = new DateTimeImmutable();

--- a/src/Credential.php
+++ b/src/Credential.php
@@ -17,8 +17,6 @@ class Credential
     /**
      * Credential constructor
      *
-     * @param Certificate $certificate
-     * @param PrivateKey $privateKey
      * @throws UnexpectedValueException Certificate does not belong to private key
      */
     public function __construct(Certificate $certificate, PrivateKey $privateKey)
@@ -35,11 +33,6 @@ class Credential
      *
      * The certificate content can be X.509 PEM, X.509 DER or X.509 DER base64
      * The private key content can be PKCS#8 DER, PKCS#8 PEM or PKCS#5 PEM
-     *
-     * @param string $certificateContents
-     * @param string $privateKeyContents
-     * @param string $passPhrase
-     * @return self
      */
     public static function create(string $certificateContents, string $privateKeyContents, string $passPhrase): self
     {
@@ -54,11 +47,6 @@ class Credential
      * File paths must be local, can have no schema or file:// schema
      * The certificate file content can be X.509 PEM, X.509 DER or X.509 DER base64
      * The private key file content can be PKCS#8 DER, PKCS#8 PEM or PKCS#5 PEM
-     *
-     * @param string $certificateFile
-     * @param string $privateKeyFile
-     * @param string $passPhrase
-     * @return self
      */
     public static function openFiles(string $certificateFile, string $privateKeyFile, string $passPhrase): self
     {

--- a/src/Credential.php
+++ b/src/Credential.php
@@ -8,11 +8,9 @@ use UnexpectedValueException;
 
 class Credential
 {
-    /** @var Certificate */
-    private $certificate;
+    private Certificate $certificate;
 
-    /** @var PrivateKey */
-    private $privateKey;
+    private PrivateKey $privateKey;
 
     /**
      * Credential constructor

--- a/src/Credential.php
+++ b/src/Credential.php
@@ -8,9 +8,9 @@ use UnexpectedValueException;
 
 class Credential
 {
-    private Certificate $certificate;
+    private readonly Certificate $certificate;
 
-    private PrivateKey $privateKey;
+    private readonly PrivateKey $privateKey;
 
     /**
      * Credential constructor

--- a/src/Internal/BaseConverter.php
+++ b/src/Internal/BaseConverter.php
@@ -17,7 +17,7 @@ use UnexpectedValueException;
  */
 class BaseConverter
 {
-    public function __construct(private BaseConverterSequence $sequence)
+    public function __construct(private readonly BaseConverterSequence $sequence)
     {
     }
 
@@ -50,7 +50,7 @@ class BaseConverter
             $input = $originalSequence[0]; // use zero as input
         }
         $chars = substr($originalSequence, 0, $frombase);
-        if (! boolval(preg_match("/^[$chars]+$/", $input))) {
+        if (! preg_match("/^[$chars]+$/", $input)) {
             throw new UnexpectedValueException('The number to convert contains invalid characters');
         }
 

--- a/src/Internal/BaseConverter.php
+++ b/src/Internal/BaseConverter.php
@@ -17,11 +17,8 @@ use UnexpectedValueException;
  */
 class BaseConverter
 {
-    private BaseConverterSequence $sequence;
-
-    public function __construct(BaseConverterSequence $sequence)
+    public function __construct(private BaseConverterSequence $sequence)
     {
-        $this->sequence = $sequence;
     }
 
     public static function createBase36(): self

--- a/src/Internal/BaseConverter.php
+++ b/src/Internal/BaseConverter.php
@@ -17,8 +17,7 @@ use UnexpectedValueException;
  */
 class BaseConverter
 {
-    /** @var BaseConverterSequence */
-    private $sequence;
+    private BaseConverterSequence $sequence;
 
     public function __construct(BaseConverterSequence $sequence)
     {

--- a/src/Internal/BaseConverterSequence.php
+++ b/src/Internal/BaseConverterSequence.php
@@ -9,11 +9,9 @@ use UnexpectedValueException;
 /** @internal  */
 class BaseConverterSequence
 {
-    /** @var string */
-    private $sequence;
+    private string $sequence;
 
-    /** @var int */
-    private $length;
+    private int $length;
 
     public function __construct(string $sequence)
     {
@@ -62,9 +60,7 @@ class BaseConverterSequence
         }
 
         $valuesCount = array_count_values(str_split(strtoupper($sequence)));
-        $repeated = array_filter($valuesCount, function (int $count): bool {
-            return 1 !== $count;
-        });
+        $repeated = array_filter($valuesCount, fn (int $count): bool => 1 !== $count);
         if ([] !== $repeated) {
             throw new UnexpectedValueException(
                 sprintf('The sequence has not unique values: "%s"', implode(', ', array_keys($repeated)))

--- a/src/Internal/BaseConverterSequence.php
+++ b/src/Internal/BaseConverterSequence.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\Credentials\Internal;
 use UnexpectedValueException;
 
 /** @internal  */
-class BaseConverterSequence
+class BaseConverterSequence implements \Stringable
 {
     private string $sequence;
 
@@ -41,7 +41,7 @@ class BaseConverterSequence
         try {
             static::checkIsValid($value);
             return true;
-        } catch (UnexpectedValueException $exception) {
+        } catch (UnexpectedValueException) {
             return false;
         }
     }

--- a/src/Internal/BaseConverterSequence.php
+++ b/src/Internal/BaseConverterSequence.php
@@ -62,7 +62,7 @@ class BaseConverterSequence
         }
 
         $valuesCount = array_count_values(str_split(strtoupper($sequence)));
-        $repeated = array_filter($valuesCount, function (int $count) {
+        $repeated = array_filter($valuesCount, function (int $count): bool {
             return 1 !== $count;
         });
         if ([] !== $repeated) {

--- a/src/Internal/BaseConverterSequence.php
+++ b/src/Internal/BaseConverterSequence.php
@@ -63,7 +63,7 @@ class BaseConverterSequence
 
         $valuesCount = array_count_values(str_split(strtoupper($sequence)));
         $repeated = array_filter($valuesCount, function (int $count) {
-            return (1 !== $count);
+            return 1 !== $count;
         });
         if ([] !== $repeated) {
             throw new UnexpectedValueException(

--- a/src/Internal/BaseConverterSequence.php
+++ b/src/Internal/BaseConverterSequence.php
@@ -9,9 +9,9 @@ use UnexpectedValueException;
 /** @internal  */
 class BaseConverterSequence implements \Stringable
 {
-    private string $sequence;
+    private readonly string $sequence;
 
-    private int $length;
+    private readonly int $length;
 
     public function __construct(string $sequence)
     {

--- a/src/Internal/DataArrayTrait.php
+++ b/src/Internal/DataArrayTrait.php
@@ -55,7 +55,7 @@ trait DataArrayTrait
         $array = [];
         foreach ($this->extractArray($key) as $name => $value) {
             if (is_scalar($value)) {
-                $array[$name] = strval($value);
+                $array[(string) $name] = strval($value);
             }
         }
         return $array;

--- a/src/Internal/Key.php
+++ b/src/Internal/Key.php
@@ -50,7 +50,6 @@ class Key
 
     /**
      * @param int $type one of OPENSSL_KEYTYPE_RSA, OPENSSL_KEYTYPE_DSA, OPENSSL_KEYTYPE_DH, OPENSSL_KEYTYPE_EC
-     * @return bool
      */
     public function isType(int $type): bool
     {

--- a/src/Internal/Key.php
+++ b/src/Internal/Key.php
@@ -9,8 +9,7 @@ class Key
 {
     use DataArrayTrait;
 
-    /** @var OpenSslKeyTypeEnum|null */
-    private $type;
+    private ?OpenSslKeyTypeEnum $type = null;
 
     /** @param array<mixed> $dataArray */
     public function __construct(array $dataArray)

--- a/src/Internal/Key.php
+++ b/src/Internal/Key.php
@@ -54,6 +54,6 @@ class Key
      */
     public function isType(int $type): bool
     {
-        return ($this->type()->index() === $type);
+        return $this->type()->index() === $type;
     }
 }

--- a/src/Internal/LocalFileOpenTrait.php
+++ b/src/Internal/LocalFileOpenTrait.php
@@ -12,7 +12,7 @@ trait LocalFileOpenTrait
 {
     private static function localFileOpen(string $filename): string
     {
-        if ('file://' === substr($filename, 0, 7)) {
+        if (str_starts_with($filename, 'file://')) {
             $filename = substr($filename, 7);
         }
 

--- a/src/Internal/Rfc4514.php
+++ b/src/Internal/Rfc4514.php
@@ -44,7 +44,6 @@ class Rfc4514
 
     /**
      * @param array<string, string> $values
-     * @return string
      */
     public function escapeArray(array $values): string
     {

--- a/src/Internal/Rfc4514.php
+++ b/src/Internal/Rfc4514.php
@@ -48,9 +48,7 @@ class Rfc4514
     public function escapeArray(array $values): string
     {
         return implode(',', array_map(
-            function (string $name, string $value): string {
-                return $this->escape($name) . '=' . $this->escape($value);
-            },
+            fn (string $name, string $value): string => $this->escape($name) . '=' . $this->escape($value),
             array_keys($values),
             $values
         ));

--- a/src/PemExtractor.php
+++ b/src/PemExtractor.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\Credentials;
 
 class PemExtractor
 {
-    public function __construct(private string $contents)
+    public function __construct(private readonly string $contents)
     {
     }
 

--- a/src/PemExtractor.php
+++ b/src/PemExtractor.php
@@ -6,8 +6,7 @@ namespace PhpCfdi\Credentials;
 
 class PemExtractor
 {
-    /** @var string */
-    private $contents;
+    private string $contents;
 
     public function __construct(string $contents)
     {

--- a/src/PemExtractor.php
+++ b/src/PemExtractor.php
@@ -6,11 +6,8 @@ namespace PhpCfdi\Credentials;
 
 class PemExtractor
 {
-    private string $contents;
-
-    public function __construct(string $contents)
+    public function __construct(private string $contents)
     {
-        $this->contents = $contents;
     }
 
     public function getContents(): string

--- a/src/PemExtractor.php
+++ b/src/PemExtractor.php
@@ -80,8 +80,6 @@ class PemExtractor
      * This won't alter CR that are not at EOL.
      * This won't alter LF+CR used in old Mac style
      *
-     * @param string $content
-     * @return string
      * @internal
      */
     protected function normalizeLineEndings(string $content): string

--- a/src/Pfx/PfxExporter.php
+++ b/src/Pfx/PfxExporter.php
@@ -12,11 +12,8 @@ class PfxExporter
 {
     use LocalFileOpenTrait;
 
-    private Credential $credential;
-
-    public function __construct(Credential $credential)
+    public function __construct(private Credential $credential)
     {
-        $this->credential = $credential;
     }
 
     public function getCredential(): Credential

--- a/src/Pfx/PfxExporter.php
+++ b/src/Pfx/PfxExporter.php
@@ -35,7 +35,7 @@ class PfxExporter
             [$this->credential->privateKey()->pem(), $this->credential->privateKey()->passPhrase()],
             $passPhrase,
         );
-        if (! $success) {
+        if (! $success || ! is_string($pfxContents)) {
             throw $this->exceptionFromLastError(sprintf(
                 'Cannot export credential with certificate %s',
                 $this->credential->certificate()->serialNumber()->bytes()

--- a/src/Pfx/PfxExporter.php
+++ b/src/Pfx/PfxExporter.php
@@ -12,8 +12,7 @@ class PfxExporter
 {
     use LocalFileOpenTrait;
 
-    /** @var Credential $credential */
-    private $credential;
+    private Credential $credential;
 
     public function __construct(Credential $credential)
     {

--- a/src/Pfx/PfxReader.php
+++ b/src/Pfx/PfxReader.php
@@ -37,9 +37,15 @@ class PfxReader
         if (! openssl_pkcs12_read($contents, $pfx, $password)) {
             throw new UnexpectedValueException('Invalid PKCS#12 contents or wrong passphrase');
         }
+        $certificate = '';
+        $privateKey = '';
+        if (is_array($pfx)) {
+            $certificate = $pfx['cert'] ?? null;
+            $privateKey = $pfx['pkey'] ?? null;
+        }
         return [
-            'cert' => $pfx['cert'] ?? '',
-            'pkey' => $pfx['pkey'] ?? '',
+            'cert' => is_string($certificate) ? $certificate : '',
+            'pkey' => is_string($privateKey) ? $privateKey : '',
         ];
     }
 }

--- a/src/PrivateKey.php
+++ b/src/PrivateKey.php
@@ -18,13 +18,12 @@ class PrivateKey extends Key
     use LocalFileOpenTrait;
 
     /** @var string PEM contents of private key */
-    private $pem;
+    private string $pem;
 
-    /** @var string */
-    private $passPhrase;
+    private string $passPhrase;
 
     /** @var PublicKey|null public key extracted from private key */
-    private $publicKey;
+    private ?PublicKey $publicKey = null;
 
     /**
      * PrivateKey constructor
@@ -47,10 +46,9 @@ class PrivateKey extends Key
         $this->pem = $pem;
         $this->passPhrase = $passPhrase;
         $dataArray = $this->callOnPrivateKey(
-            function ($privateKey): array {
+            fn ($privateKey): array =>
                 // no need to verify that openssl_pkey_get_details returns false since it is already open
-                return openssl_pkey_get_details($privateKey) ?: [];
-            }
+                openssl_pkey_get_details($privateKey) ?: []
         );
         parent::__construct($dataArray);
     }
@@ -132,9 +130,7 @@ class PrivateKey extends Key
     public function belongsToPEMCertificate(string $certificate): bool
     {
         return $this->callOnPrivateKey(
-            function ($privateKey) use ($certificate): bool {
-                return openssl_x509_check_private_key($certificate, $privateKey);
-            }
+            fn ($privateKey): bool => openssl_x509_check_private_key($certificate, $privateKey)
         );
     }
 

--- a/src/PrivateKey.php
+++ b/src/PrivateKey.php
@@ -129,7 +129,7 @@ class PrivateKey extends Key
      */
     protected function openSslSign(string $data, ?string &$signature, $privateKey, int $algorithm): bool
     {
-        return openssl_sign($data, $signature, $privateKey, $algorithm);
+        return openssl_sign($data, $signature, $privateKey, $algorithm); // @phpstan-ignore parameterByRef.type
     }
 
     public function belongsTo(Certificate $certificate): bool
@@ -184,11 +184,14 @@ class PrivateKey extends Key
                     'private_key_bits' => $this->publicKey()->numberOfBits(),
                     'encrypt_key' => ('' !== $newPassPhrase), // if empty then set that the key is not encrypted
                 ];
+                // @codeCoverageIgnoreStart
                 if (! openssl_pkey_export($privateKey, $exported, $newPassPhrase, $exportConfig)) {
-                    // @codeCoverageIgnoreStart
                     throw new RuntimeException('Cannot export the private KEY to change password');
-                    // @codeCoverageIgnoreEnd
                 }
+                if (! is_string($exported) || '' === $exported) {
+                    throw new RuntimeException('Exported KEY has not a valid content');
+                }
+                // @codeCoverageIgnoreEnd
                 return $exported;
             }
         );

--- a/src/PrivateKey.php
+++ b/src/PrivateKey.php
@@ -59,8 +59,6 @@ class PrivateKey extends Key
      * Convert PKCS#8 DER to PKCS#8 PEM
      *
      * @param string $contents can be a PKCS#8 DER
-     * @param bool $isEncrypted
-     * @return string
      */
     public static function convertDerToPem(string $contents, bool $isEncrypted): string
     {
@@ -75,8 +73,6 @@ class PrivateKey extends Key
      * The content file can be a PKCS#8 DER, PKCS#8 PEM or PKCS#5 PEM
      *
      * @param string $filename must be a local file (without scheme or file:// scheme)
-     * @param string $passPhrase
-     * @return self
      */
     public static function openFile(string $filename, string $passPhrase): self
     {
@@ -120,11 +116,7 @@ class PrivateKey extends Key
     /**
      * This method id created to wrap and mock openssl_sign
      *
-     * @param string $data
-     * @param string|null $signature
      * @param OpenSSLAsymmetricKey $privateKey
-     * @param int $algorithm
-     * @return bool
      * @internal
      */
     protected function openSslSign(string $data, ?string &$signature, $privateKey, int $algorithm): bool
@@ -174,7 +166,6 @@ class PrivateKey extends Key
      * Export the current private key to a new private key with a different password
      *
      * @param string $newPassPhrase If empty the new private key will be unencrypted
-     * @return self
      */
     public function changePassPhrase(string $newPassPhrase): self
     {

--- a/src/PrivateKey.php
+++ b/src/PrivateKey.php
@@ -11,8 +11,6 @@ use PhpCfdi\Credentials\Internal\LocalFileOpenTrait;
 use RuntimeException;
 use UnexpectedValueException;
 
-use const PHP_VERSION_ID;
-
 class PrivateKey extends Key
 {
     use LocalFileOpenTrait;
@@ -147,15 +145,7 @@ class PrivateKey extends Key
         if (false === $privateKey) {
             throw new RuntimeException('Cannot open private key: ' . openssl_error_string());
         }
-        try {
-            return $function($privateKey);
-        } finally {
-            if (PHP_VERSION_ID < 80000) {
-                // phpcs:disable Generic.PHP.DeprecatedFunctions.Deprecated
-                openssl_free_key($privateKey);
-                // phpcs:enable
-            }
-        }
+        return $function($privateKey);
     }
 
     /**

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -19,10 +19,9 @@ class PublicKey extends Key
     public function __construct(string $source)
     {
         $dataArray = $this->callOnPublicKeyWithContents(
-            function ($publicKey): array {
+            fn ($publicKey): array =>
                 // no need to verify that openssl_pkey_get_details returns false since it is already open
-                return openssl_pkey_get_details($publicKey) ?: [];
-            },
+                openssl_pkey_get_details($publicKey) ?: [],
             $source
         );
         parent::__construct($dataArray);

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -10,8 +10,6 @@ use PhpCfdi\Credentials\Internal\Key;
 use PhpCfdi\Credentials\Internal\LocalFileOpenTrait;
 use RuntimeException;
 
-use const PHP_VERSION_ID;
-
 class PublicKey extends Key
 {
     use LocalFileOpenTrait;
@@ -92,14 +90,6 @@ class PublicKey extends Key
         if (false === $pubKey) {
             throw new RuntimeException('Cannot open public key: ' . openssl_error_string());
         }
-        try {
-            return $function($pubKey);
-        } finally {
-            if (PHP_VERSION_ID < 80000) {
-                // phpcs:disable Generic.PHP.DeprecatedFunctions.Deprecated
-                openssl_free_key($pubKey);
-                // phpcs:enable
-            }
-        }
+        return $function($pubKey);
     }
 }

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -36,11 +36,7 @@ class PublicKey extends Key
     /**
      * Verify the signature of some data
      *
-     * @param string $data
-     * @param string $signature
-     * @param int $algorithm
      *
-     * @return bool
      *
      * @throws RuntimeException when openssl report an error on verify
      */
@@ -61,11 +57,7 @@ class PublicKey extends Key
     /**
      * This method id created to wrap and mock openssl_verify
      *
-     * @param string $data
-     * @param string $signature
      * @param OpenSSLAsymmetricKey $publicKey
-     * @param int $algorithm
-     * @return int
      */
     protected function openSslVerify(string $data, string $signature, $publicKey, int $algorithm): int
     {
@@ -91,7 +83,6 @@ class PublicKey extends Key
     /**
      * @template T
      * @param Closure(OpenSSLAsymmetricKey): T $function
-     * @param string $publicKeyContents
      * @return T
      * @throws RuntimeException when Cannot open public key
      */

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -53,7 +53,7 @@ class PublicKey extends Key
                     /** @codeCoverageIgnore Don't know how make openssl_verify returns -1 */
                     throw new RuntimeException('Verify error: ' . openssl_error_string());
                 }
-                return (1 === $verify);
+                return 1 === $verify;
             }
         );
     }

--- a/src/PublicKey.php
+++ b/src/PublicKey.php
@@ -18,7 +18,7 @@ class PublicKey extends Key
 
     public function __construct(string $source)
     {
-        $dataArray = self::callOnPublicKeyWithContents(
+        $dataArray = $this->callOnPublicKeyWithContents(
             function ($publicKey): array {
                 // no need to verify that openssl_pkey_get_details returns false since it is already open
                 return openssl_pkey_get_details($publicKey) ?: [];
@@ -86,7 +86,7 @@ class PublicKey extends Key
      * @return T
      * @throws RuntimeException when Cannot open public key
      */
-    private static function callOnPublicKeyWithContents(Closure $function, string $publicKeyContents)
+    private function callOnPublicKeyWithContents(Closure $function, string $publicKeyContents)
     {
         /** @var false|OpenSSLAsymmetricKey $pubKey */
         $pubKey = openssl_get_publickey($publicKeyContents);

--- a/src/SerialNumber.php
+++ b/src/SerialNumber.php
@@ -14,22 +14,21 @@ use UnexpectedValueException;
  */
 class SerialNumber
 {
-    /** @var string Hexadecimal representation */
-    private string $hexadecimal;
-
-    public function __construct(string $hexadecimal)
+    /**
+     * @param string $hexadecimal Hexadecimal representation
+     */
+    public function __construct(private string $hexadecimal)
     {
-        if ('' === $hexadecimal) {
+        if ('' === $this->hexadecimal) {
             throw new UnexpectedValueException('The hexadecimal string is empty');
         }
-        if (0 === strcasecmp('0x', substr($hexadecimal, 0, 2))) {
-            $hexadecimal = substr($hexadecimal, 2);
+        if (0 === strcasecmp('0x', substr($this->hexadecimal, 0, 2))) {
+            $this->hexadecimal = substr($this->hexadecimal, 2);
         }
-        $hexadecimal = strtoupper($hexadecimal);
-        if (! preg_match('/^[0-9A-F]*$/', $hexadecimal)) {
+        $this->hexadecimal = strtoupper($this->hexadecimal);
+        if (! preg_match('/^[0-9A-F]*$/', $this->hexadecimal)) {
             throw new UnexpectedValueException('The hexadecimal string contains invalid characters');
         }
-        $this->hexadecimal = $hexadecimal;
     }
 
     public static function createFromHexadecimal(string $hexadecimal): self

--- a/src/SerialNumber.php
+++ b/src/SerialNumber.php
@@ -15,7 +15,7 @@ use UnexpectedValueException;
 class SerialNumber
 {
     /** @var string Hexadecimal representation */
-    private $hexadecimal;
+    private string $hexadecimal;
 
     public function __construct(string $hexadecimal)
     {

--- a/tests/Unit/Internal/BaseConverterTest.php
+++ b/tests/Unit/Internal/BaseConverterTest.php
@@ -29,7 +29,6 @@ class BaseConverterTest extends TestCase
     }
 
     /**
-     * @param int $base
      * @testWith [-1]
      *           [0]
      *           [1]
@@ -45,7 +44,6 @@ class BaseConverterTest extends TestCase
     }
 
     /**
-     * @param int $base
      * @testWith [-1]
      *           [0]
      *           [1]

--- a/tests/Unit/Internal/LocalFileOpenTraitTest.php
+++ b/tests/Unit/Internal/LocalFileOpenTraitTest.php
@@ -62,7 +62,6 @@ class LocalFileOpenTraitTest extends TestCase
     /**
      * This test ensures that the correct exception is thrown
      *
-     * @param string $filename
      * @testWith ["c:/certs/file.txt"]
      *           ["file://c:/certs/file.txt"]
      *           ["c:\\certs\\file.txt"]

--- a/tests/Unit/Internal/Rfc4514Test.php
+++ b/tests/Unit/Internal/Rfc4514Test.php
@@ -10,8 +10,6 @@ use PhpCfdi\Credentials\Tests\TestCase;
 class Rfc4514Test extends TestCase
 {
     /**
-     * @param string $subject
-     * @param string $expected
      * @dataProvider providerEscape
      */
     public function testEscape(string $subject, string $expected): void

--- a/tests/Unit/Internal/Rfc4514Test.php
+++ b/tests/Unit/Internal/Rfc4514Test.php
@@ -38,7 +38,7 @@ class Rfc4514Test extends TestCase
     }
 
     /** @return array<string, array<string>> */
-    public function providerEscape(): array
+    public static function providerEscape(): array
     {
         return [
             'normal' => ['foo bar', 'foo bar'],

--- a/tests/Unit/PemExtractorTest.php
+++ b/tests/Unit/PemExtractorTest.php
@@ -19,7 +19,7 @@ class PemExtractorTest extends TestCase
     }
 
     /** @return array<string, array<string>> */
-    public function providerCrLfAndLf(): array
+    public static function providerCrLfAndLf(): array
     {
         return [
             'CRLF' => ["\r\n"],

--- a/tests/Unit/PemExtractorTest.php
+++ b/tests/Unit/PemExtractorTest.php
@@ -28,7 +28,6 @@ class PemExtractorTest extends TestCase
     }
 
     /**
-     * @param string $eol
      * @dataProvider providerCrLfAndLf
      */
     public function testExtractorWithFakeContent(string $eol): void

--- a/tests/Unit/Pfx/PfxExporterTest.php
+++ b/tests/Unit/Pfx/PfxExporterTest.php
@@ -14,8 +14,7 @@ use RuntimeException;
 
 class PfxExporterTest extends TestCase
 {
-    /** @var string */
-    private $credentialPassphrase;
+    private string $credentialPassphrase;
 
     protected function setUp(): void
     {

--- a/tests/Unit/PrivateKeyTest.php
+++ b/tests/Unit/PrivateKeyTest.php
@@ -102,7 +102,7 @@ class PrivateKeyTest extends TestCase
     }
 
     /** @return array<string, array{string, bool}> */
-    public function providerBelongsTo(): array
+    public static function providerBelongsTo(): array
     {
         return [
             'paired certificate' => ['FIEL_AAA010101AAA/certificate.cer', true],
@@ -122,7 +122,7 @@ class PrivateKeyTest extends TestCase
     }
 
     /** @return array<string, array{string, string}> */
-    public function providerChangePassPhrase(): array
+    public static function providerChangePassPhrase(): array
     {
         return [
             'clear password' => ['', 'PRIVATE KEY'],

--- a/tests/Unit/SerialNumberTest.php
+++ b/tests/Unit/SerialNumberTest.php
@@ -65,7 +65,7 @@ class SerialNumberTest extends TestCase
     }
 
     /** @return array<string, array{string, string, string, bool}> */
-    public function providerSerialNumbersNotIssuedFromSat(): array
+    public static function providerSerialNumbersNotIssuedFromSat(): array
     {
         return [
             'Mifiel pruebas' => ['272B', '10027', "'+", true],

--- a/tests/Unit/SerialNumberTest.php
+++ b/tests/Unit/SerialNumberTest.php
@@ -17,7 +17,6 @@ class SerialNumberTest extends TestCase
     public const SERIAL_DECIMAL = '292233162870206001759766198425879490508935868472';
 
     /**
-     * @param string $prefix
      * @testWith [""]
      *           ["0X"]
      *           ["0x"]


### PR DESCRIPTION
- Se mejoran las declaraciones de tipos.
- Se elimina la compatiblidad con PHP 7.3, PHP 7.4 y PHP 8.0.
- Se actualiza la acción de GitHub a `Update to SonarSource/sonarqube-scan-action@v5`.